### PR TITLE
Add toast notification when adding tasks

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -473,6 +473,16 @@ class _TodoHomePageState extends State<TodoHomePage> {
             );
           }
         }
+
+        // Afficher un toast de confirmation
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('Tâche "${newTodo.title}" ajoutée'),
+              duration: const Duration(seconds: 2),
+            ),
+          );
+        }
       }
     });
   }
@@ -1914,6 +1924,16 @@ class _AddTodoModalState extends State<AddTodoModal> {
         );
         _subTasks.add(subTask);
         _subTaskController.clear();
+
+        // Afficher un toast de confirmation
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('Sous-tâche "${subTask.title}" ajoutée'),
+              duration: const Duration(seconds: 2),
+            ),
+          );
+        }
       });
     }
   }
@@ -2345,9 +2365,19 @@ class _EditTodoModalState extends State<EditTodoModal> {
         
         // Sauvegarder immédiatement
         widget.homeState._saveData();
-        
+
         _subTaskController.clear();
         debugPrint('✅ _addSubTask(): Sous-tâche "${subTask.title}" ajoutée et sauvegardée');
+
+        // Afficher un toast de confirmation
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('Sous-tâche "${subTask.title}" ajoutée'),
+              duration: const Duration(seconds: 2),
+            ),
+          );
+        }
       } catch (e) {
         debugPrint('❌ _addSubTask(): Erreur lors de l\'ajout de la sous-tâche: $e');
         ScaffoldMessenger.of(context).showSnackBar(


### PR DESCRIPTION
## Summary
- show a toast when creating a new task
- show a toast when creating subtasks in add and edit modals

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888f417ef108321a21d275682e8bc7e