### PR TITLE
feat: add voice task creation

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -68,9 +68,13 @@ dependencies:
   
   # Gestion des permissions et accès aux fichiers
   permission_handler: ^11.3.1
-  
+
   # Gestion des chemins de fichiers
   path_provider: ^2.1.2
+
+  # Enregistrement audio et requêtes HTTP
+  record: ^5.0.4
+  http: ^1.2.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add microphone floating button to record tasks and send audio to OpenAI for structured JSON
- allow configuring OpenAI API keys in settings
- include record and http dependencies for audio capture and API calls

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e99621e808321899be34933506ece