### PR TITLE
Add voice task creation using OpenAI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Toutes les modifications notables de ce projet seront documentées dans ce fichi
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.0.0/),
 et ce projet adhère au [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2025-01-01
+
+### Ajouté
+- ✅ Création de tâches par commande vocale via OpenAI
+- ✅ Champ de configuration pour les clés API OpenAI
+
 ## [1.0.0] - 2024-12-19
 
 ### Ajouté

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Une application de gestion de tâches intuitive, offrant une expérience utilisa
 - ✅ Marquage rapide comme terminée
 - ✅ Suppression avec confirmation
 - ✅ Édition complète des propriétés
+- ✅ Ajout de tâches par commande vocale (Whisper + GPT)
 
 ### Système de projets
 - ✅ Création de projets avec couleurs personnalisées

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -68,9 +68,15 @@ dependencies:
   
   # Gestion des permissions et accès aux fichiers
   permission_handler: ^11.3.1
-  
+
   # Gestion des chemins de fichiers
   path_provider: ^2.1.2
+
+  # Enregistrement audio et requêtes HTTP
+  # Utilisation d'une version du plugin de capture audio compatible avec Linux
+  # pour éviter l'erreur `RecordLinux` manquant `startStream`.
+  record: ^4.4.3
+  http: ^1.2.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add microphone floating button and workflow to record audio, transcribe with Whisper, and create structured tasks
- allow users to store OpenAI API keys in settings
- include record and http packages for audio capture and API requests
- document voice task creation feature

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e99621e808321899be34933506ece