### PR TITLE
Improve subtasks interactions and notification persistence

### DIFF
--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -70,6 +70,7 @@ class NotificationService {
           category: NotificationCategory.Reminder,
           payload: payload, // Inclure les données de navigation
           groupKey: 'todo_reminder_$id', // GroupKey unique par notification pour éviter le groupement automatique
+          autoDismissible: false, // Ne pas retirer automatiquement en ouvrant l'app
         ),
         schedule: NotificationCalendar.fromDate(
           date: scheduledDate,
@@ -92,6 +93,16 @@ class NotificationService {
       debugPrint('Notification annulée pour ID: $id');
     } catch (e) {
       debugPrint('❌ Erreur lors de l\'annulation de la notification: $e');
+    }
+  }
+
+  /// Ferme uniquement une notification affichée
+  static Future<void> dismissNotification(int id) async {
+    try {
+      await AwesomeNotifications().dismiss(id);
+      debugPrint('Notification fermée pour ID: $id');
+    } catch (e) {
+      debugPrint('❌ Erreur lors de la fermeture de la notification: $e');
     }
   }
 


### PR DESCRIPTION
## Summary
- allow checking and prioritizing newly added subtasks at the top in detailed views
- expand voice input prompts and parsing to capture structured subtasks and save them under the dictated task
- keep reminders visible until tapped and dismiss only the notification the user opens

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693beec2e0fc8321b6710c7fd40b220c)